### PR TITLE
Added svg file information

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ angular.module('myApp', ['star-rating'])
 <star-rating-comp rating="'3.0'"></star-rating-comp>
 ```
 
+**Note: You need to provide the svg file under assets/images location.**
+
 ## Component Properties
 
 ### Input (< bindings)


### PR DESCRIPTION
I implemented this plugin but the stars for rating was not showing although its element was present in the DOM, then after inspecting, i figured out to add an svg icon for the stars under assets/images directory.